### PR TITLE
feat(security): POST /api/device-tokens — credential-less mint for na…

### DIFF
--- a/.env
+++ b/.env
@@ -29,6 +29,11 @@ ALLOWED_ORIGIN=
 # Rate limiter toggle — on by default; tests override to false.
 RATE_LIMIT_ENABLED=true
 
+# Member row that the public /api/device-tokens endpoint binds every minted
+# token to. Set per-deployment to an existing enabled Member.id (no secret —
+# the value is opaque, and the rate limiter sits in front of the endpoint).
+DEVICE_MEMBER_ID=
+
 # Reverse-proxy / host trust list consumed by public/index.php.
 TRUSTED_PROXIES=
 TRUSTED_HOSTS=

--- a/.env.test.dist
+++ b/.env.test.dist
@@ -24,6 +24,7 @@ KERNEL_CLASS='App\Kernel'
 
 # Test-only fixtures + scaffolding consumed by integration tests.
 API_CLIENT_SECRET=''
+DEVICE_MEMBER_ID='1'
 BENCHMARK_HOST=''
 DEBUG=
 GITHUB_API_TOKEN=

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -5,6 +5,14 @@ framework:
             limit: 3
             rate: { interval: '6 seconds', amount: 1 }
             cache_pool: cache.rate_limiter
+        device_token_mint:
+            # Device clients (Compose Multiplatform desktop/Android/iOS) hit this
+            # with no shared secret. Generous burst tolerates initial mint + a
+            # refresh per hour or so; steady refill stays well below abuse.
+            policy: 'token_bucket'
+            limit: 6
+            rate: { interval: '1 minute', amount: 1 }
+            cache_pool: cache.rate_limiter
         highlights:
             policy: 'sliding_window'
             limit: 60

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,6 +23,7 @@ when@prod:
         access_control:
             - { path: ^/api/healthcheck,            role: PUBLIC_ACCESS }
             - { path: ^/api/token,                  role: PUBLIC_ACCESS }
+            - { path: ^/api/device-tokens,          role: PUBLIC_ACCESS }
             - { path: ^/api/docs,                   role: PUBLIC_ACCESS }
             - { path: ^/api/tiktok/oauth/callback,  role: PUBLIC_ACCESS }
             - { path: ^/api/tiktok/webhook/callback, role: PUBLIC_ACCESS }
@@ -33,6 +34,7 @@ when@dev:
         access_control:
             - { path: ^/api/healthcheck,            role: PUBLIC_ACCESS }
             - { path: ^/api/token,                  role: PUBLIC_ACCESS }
+            - { path: ^/api/device-tokens,          role: PUBLIC_ACCESS }
             - { path: ^/api/docs,                   role: PUBLIC_ACCESS }
             - { path: ^/api/tiktok/oauth/callback,  role: PUBLIC_ACCESS }
             - { path: ^/api/tiktok/webhook/callback, role: PUBLIC_ACCESS }
@@ -43,6 +45,7 @@ when@test:
         access_control:
             - { path: ^/api/healthcheck,            role: PUBLIC_ACCESS }
             - { path: ^/api/token,                  role: PUBLIC_ACCESS }
+            - { path: ^/api/device-tokens,          role: PUBLIC_ACCESS }
             - { path: ^/api/docs,                   role: PUBLIC_ACCESS }
             - { path: ^/api/tiktok/oauth/callback,  role: PUBLIC_ACCESS }
             - { path: ^/api/tiktok/webhook/callback, role: PUBLIC_ACCESS }

--- a/config/services/security.yml
+++ b/config/services/security.yml
@@ -20,6 +20,16 @@ services:
 
     App\Security\Infrastructure\ApiPlatform\State\TokenProcessor: ~
 
+    App\Security\Domain\DeviceTokenMinter:
+        arguments:
+            $store:          '@App\Security\Domain\AccessTokenStore'
+            $deviceMemberId: '%env(string:DEVICE_MEMBER_ID)%'
+            $ttlSeconds:     900
+
+    App\Security\Infrastructure\ApiPlatform\State\DeviceTokenProcessor:
+        arguments:
+            $minter: '@App\Security\Domain\DeviceTokenMinter'
+
     # NewsReview wiring (Highlight resource)
     App\NewsReview\Domain\Snapshot\SnapshotReader:
         class: App\NewsReview\Infrastructure\Repository\FilesystemSnapshotReader
@@ -48,9 +58,10 @@ services:
 
     App\Security\Infrastructure\Http\RateLimitSubscriber:
         arguments:
-            $tokenMintLimiterFactory:  '@limiter.token_mint'
-            $highlightsLimiterFactory: '@limiter.highlights'
-            $docsLimiterFactory:       '@limiter.docs'
+            $tokenMintLimiterFactory:        '@limiter.token_mint'
+            $deviceTokenMintLimiterFactory:  '@limiter.device_token_mint'
+            $highlightsLimiterFactory:       '@limiter.highlights'
+            $docsLimiterFactory:             '@limiter.docs'
             $logger: '@logger'
             $enabled: '%env(bool:RATE_LIMIT_ENABLED)%'
         tags:

--- a/src/Security/Domain/DeviceTokenDto.php
+++ b/src/Security/Domain/DeviceTokenDto.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Security\Domain;
+
+/**
+ * Output shape returned by POST /api/device-tokens.
+ *
+ * Field names match what the native data layer's ApiClient.mintDeviceToken()
+ * expects so the Compose Multiplatform binary needs no further adapter.
+ */
+final readonly class DeviceTokenDto
+{
+    public function __construct(
+        public string $token,
+        public int $expiresInSec,
+    ) {
+    }
+}

--- a/src/Security/Domain/DeviceTokenMinter.php
+++ b/src/Security/Domain/DeviceTokenMinter.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Security\Domain;
+
+/**
+ * Mints a short-lived Bearer for an installed app instance — no client secret.
+ *
+ * All device tokens map onto a single configured "device" Member ID. The Member
+ * row exists so the rest of the auth stack (ApiAccessTokenHandler → UserBadge)
+ * keeps working unchanged; downstream authorization sees a ROLE_USER principal.
+ *
+ * Anonymity / abuse is bounded by the rate limiter sitting in front of the
+ * /api/device-tokens endpoint (RateLimitSubscriber + limiter.device_token_mint).
+ */
+final readonly class DeviceTokenMinter
+{
+    public function __construct(
+        private AccessTokenStore $store,
+        private string $deviceMemberId,
+        private int $ttlSeconds = 900,
+    ) {
+    }
+
+    public function mint(): DeviceTokenDto
+    {
+        $token = bin2hex(random_bytes(32));
+        $this->store->put($token, $this->deviceMemberId, $this->ttlSeconds);
+
+        return new DeviceTokenDto(token: $token, expiresInSec: $this->ttlSeconds);
+    }
+
+    public function ttlSeconds(): int
+    {
+        return $this->ttlSeconds;
+    }
+}

--- a/src/Security/Infrastructure/ApiPlatform/Resource/DeviceToken.php
+++ b/src/Security/Infrastructure/ApiPlatform/Resource/DeviceToken.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Security\Infrastructure\ApiPlatform\Resource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use App\Security\Domain\DeviceTokenDto;
+use App\Security\Infrastructure\ApiPlatform\State\DeviceTokenProcessor;
+
+/**
+ * Public mint endpoint for the native (Compose Multiplatform) clients.
+ *
+ * Unlike POST /api/token (server-to-server with Basic client credentials), this
+ * endpoint takes no shared secret: anything with the right rate-limit budget
+ * can request a token. That trade-off is acceptable because:
+ *   - the binary cannot carry a secret safely anyway,
+ *   - tokens are short-lived,
+ *   - the rate limiter enforces a per-IP ceiling.
+ */
+#[ApiResource(
+    shortName: 'DeviceToken',
+    operations: [
+        new Post(
+            uriTemplate: '/device-tokens',
+            security: 'is_granted("PUBLIC_ACCESS")',
+            input: DeviceTokenMintRequest::class,
+            output: DeviceTokenDto::class,
+            processor: DeviceTokenProcessor::class,
+        ),
+    ],
+)]
+final class DeviceToken
+{
+}

--- a/src/Security/Infrastructure/ApiPlatform/Resource/DeviceTokenMintRequest.php
+++ b/src/Security/Infrastructure/ApiPlatform/Resource/DeviceTokenMintRequest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Security\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Body shape accepted by POST /api/device-tokens.
+ *
+ * `installId` is a client-rotated opaque identifier (UUID-shaped); it is not a
+ * credential — anyone holding it can mint a token. The rate limiter caps the
+ * mint frequency. The native app rotates installId on 403, mirroring the
+ * device-locked policy enforced by the API.
+ */
+final class DeviceTokenMintRequest
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 1, max: 32)]
+        #[Assert\Regex(pattern: '/^[a-z0-9_-]+$/i', message: 'platform must be alphanumeric')]
+        public ?string $platform = null,
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 1, max: 32)]
+        public ?string $appVersion = null,
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 8, max: 128)]
+        #[Assert\Regex(pattern: '/^[a-z0-9_-]+$/i', message: 'installId must be alphanumeric (URL-safe)')]
+        public ?string $installId = null,
+    ) {
+    }
+}

--- a/src/Security/Infrastructure/ApiPlatform/State/DeviceTokenProcessor.php
+++ b/src/Security/Infrastructure/ApiPlatform/State/DeviceTokenProcessor.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Security\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Security\Domain\DeviceTokenDto;
+use App\Security\Domain\DeviceTokenMinter;
+use App\Security\Infrastructure\ApiPlatform\Resource\DeviceTokenMintRequest;
+
+/**
+ * @implements ProcessorInterface<DeviceTokenMintRequest, DeviceTokenDto>
+ */
+final readonly class DeviceTokenProcessor implements ProcessorInterface
+{
+    public function __construct(private DeviceTokenMinter $minter)
+    {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): DeviceTokenDto
+    {
+        // The {platform, appVersion, installId} payload is currently consumed
+        // for shape validation only — every device token resolves to the same
+        // configured Member ID. Per-installId provenance would land here once
+        // an InstallIdRegistry exists (separate change).
+        return $this->minter->mint();
+    }
+}

--- a/src/Security/Infrastructure/Http/RateLimitSubscriber.php
+++ b/src/Security/Infrastructure/Http/RateLimitSubscriber.php
@@ -16,6 +16,7 @@ final class RateLimitSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly RateLimiterFactory $tokenMintLimiterFactory,
+        private readonly RateLimiterFactory $deviceTokenMintLimiterFactory,
         private readonly RateLimiterFactory $highlightsLimiterFactory,
         private readonly RateLimiterFactory $docsLimiterFactory,
         private readonly LoggerInterface $logger,
@@ -66,6 +67,9 @@ final class RateLimitSubscriber implements EventSubscriberInterface
         }
         if ($path === '/api/token') {
             return $this->tokenMintLimiterFactory;
+        }
+        if ($path === '/api/device-tokens') {
+            return $this->deviceTokenMintLimiterFactory;
         }
         if (str_starts_with($path, '/api/docs')) {
             return $this->docsLimiterFactory;

--- a/tests/Security/Domain/DeviceTokenMinterTest.php
+++ b/tests/Security/Domain/DeviceTokenMinterTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Security\Domain;
+
+use App\Security\Domain\DeviceTokenMinter;
+use PHPUnit\Framework\TestCase;
+
+class DeviceTokenMinterTest extends TestCase
+{
+    private const DEVICE_MEMBER_ID = '7';
+
+    public function test_returns_64_hex_token_and_configured_ttl(): void
+    {
+        $store = new InMemoryAccessTokenStore();
+        $minter = new DeviceTokenMinter($store, self::DEVICE_MEMBER_ID, ttlSeconds: 900);
+
+        $dto = $minter->mint();
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $dto->token);
+        self::assertSame(900, $dto->expiresInSec);
+    }
+
+    public function test_persists_token_against_device_member_id(): void
+    {
+        $store = new InMemoryAccessTokenStore();
+        $minter = new DeviceTokenMinter($store, self::DEVICE_MEMBER_ID, ttlSeconds: 900);
+
+        $dto = $minter->mint();
+
+        $record = $store->resolve($dto->token);
+        self::assertNotNull($record);
+        self::assertSame(self::DEVICE_MEMBER_ID, $record->memberId);
+    }
+
+    public function test_each_call_returns_a_distinct_token(): void
+    {
+        $store = new InMemoryAccessTokenStore();
+        $minter = new DeviceTokenMinter($store, self::DEVICE_MEMBER_ID, ttlSeconds: 60);
+
+        $tokens = [$minter->mint()->token, $minter->mint()->token, $minter->mint()->token];
+
+        self::assertCount(3, array_unique($tokens));
+    }
+}

--- a/tests/Security/Infrastructure/ApiPlatform/State/DeviceTokenResourceTest.php
+++ b/tests/Security/Infrastructure/ApiPlatform/State/DeviceTokenResourceTest.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Security\Infrastructure\ApiPlatform\State;
+
+use App\Membership\Domain\Entity\Member;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * End-to-end check for POST /api/device-tokens — the public, no-secret mint
+ * endpoint consumed by the Compose Multiplatform desktop/Android/iOS clients.
+ *
+ * The endpoint MUST accept {platform, appVersion, installId}, return
+ * {token, expiresInSec}, and reject malformed payloads with 422. The native
+ * data layer's DeviceTokenInterceptor depends on this exact contract.
+ *
+ * @group http
+ */
+class DeviceTokenResourceTest extends WebTestCase
+{
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->client->catchExceptions(true);
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($em);
+        $metadata = $em->getMetadataFactory()->getAllMetadata();
+        if ($metadata !== []) {
+            $schemaTool->dropSchema($metadata);
+            $schemaTool->createSchema($metadata);
+        }
+
+        // .env.test.dist sets DEVICE_MEMBER_ID=1 — create a Member with id=1
+        // so ApiAccessTokenHandler can resolve a UserBadge from the minted token.
+        $member = new Member();
+        $member->apiKey = 'device-member-key';
+        $member->setEnabled(true);
+        $member->setUsername('device');
+        $em->persist($member);
+        $em->flush();
+    }
+
+    public function test_valid_payload_returns_token_and_expiry(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/device-tokens',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode([
+                'platform'   => 'desktop',
+                'appVersion' => '22',
+                'installId'  => 'probe-0001',
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $response = $this->client->getResponse();
+        self::assertSame(201, $response->getStatusCode(), $response->getContent() ?: 'no body');
+
+        $body = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $body['token']);
+        self::assertSame(900, $body['expiresInSec']);
+    }
+
+    public function test_each_call_returns_a_distinct_token(): void
+    {
+        $payload = json_encode([
+            'platform'   => 'desktop',
+            'appVersion' => '22',
+            'installId'  => 'probe-0002',
+        ], JSON_THROW_ON_ERROR);
+
+        $tokens = [];
+        foreach (range(1, 3) as $_) {
+            $this->client->request(
+                'POST',
+                '/api/device-tokens',
+                server: ['CONTENT_TYPE' => 'application/json'],
+                content: $payload,
+            );
+            self::assertSame(201, $this->client->getResponse()->getStatusCode());
+            $body = json_decode((string) $this->client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            $tokens[] = $body['token'];
+        }
+
+        self::assertCount(3, array_unique($tokens));
+    }
+
+    public function test_missing_install_id_returns_422(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/device-tokens',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['platform' => 'desktop', 'appVersion' => '22'], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertSame(422, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function test_garbage_install_id_returns_422(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/device-tokens',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode([
+                'platform'   => 'desktop',
+                'appVersion' => '22',
+                'installId'  => '!! not safe !!',
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertSame(422, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function test_no_authorization_header_required(): void
+    {
+        $this->client->request(
+            'POST',
+            '/api/device-tokens',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode([
+                'platform'   => 'desktop',
+                'appVersion' => '22',
+                'installId'  => 'probe-0003',
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        // 201 confirms PUBLIC_ACCESS allowed the call through without any
+        // Basic/Bearer header — that's the contract the native app relies on.
+        self::assertSame(201, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Security/Infrastructure/Http/RateLimitSubscriberTest.php
+++ b/tests/Security/Infrastructure/Http/RateLimitSubscriberTest.php
@@ -19,6 +19,7 @@ class RateLimitSubscriberTest extends TestCase
     {
         $subscriber = new RateLimitSubscriber(
             tokenMintLimiterFactory: $this->permissiveFactory('token_mint'),
+            deviceTokenMintLimiterFactory: $this->permissiveFactory('device_token_mint'),
             highlightsLimiterFactory: $this->tightFactory('highlights'),
             docsLimiterFactory: $this->tightFactory('docs'),
             logger: new NullLogger(),
@@ -35,6 +36,7 @@ class RateLimitSubscriberTest extends TestCase
     {
         $subscriber = new RateLimitSubscriber(
             tokenMintLimiterFactory: $this->permissiveFactory('token_mint'),
+            deviceTokenMintLimiterFactory: $this->permissiveFactory('device_token_mint'),
             highlightsLimiterFactory: $this->tightFactory('highlights'),
             docsLimiterFactory: $this->tightFactory('docs'),
             logger: new NullLogger(),
@@ -53,6 +55,7 @@ class RateLimitSubscriberTest extends TestCase
         $factory = $this->tightFactory('highlights', limit: 2);
         $subscriber = new RateLimitSubscriber(
             tokenMintLimiterFactory: $this->permissiveFactory('token_mint'),
+            deviceTokenMintLimiterFactory: $this->permissiveFactory('device_token_mint'),
             highlightsLimiterFactory: $factory,
             docsLimiterFactory: $this->permissiveFactory('docs'),
             logger: new NullLogger(),
@@ -81,6 +84,7 @@ class RateLimitSubscriberTest extends TestCase
         $factory = $this->tightFactory('highlights', limit: 1);
         $subscriber = new RateLimitSubscriber(
             tokenMintLimiterFactory: $this->permissiveFactory('token_mint'),
+            deviceTokenMintLimiterFactory: $this->permissiveFactory('device_token_mint'),
             highlightsLimiterFactory: $factory,
             docsLimiterFactory: $this->permissiveFactory('docs'),
             logger: new NullLogger(),


### PR DESCRIPTION
…tive clients

The Compose Multiplatform desktop/Android/iOS port can't safely embed NUXT_API_CLIENT_SECRET (the binary is distributable; the secret would leak). This endpoint accepts {platform, appVersion, installId} with no Authorization header and mints a short-lived Bearer scoped to a single configured Member.

- DeviceToken (#[ApiResource POST '/device-tokens', PUBLIC_ACCESS]) + DeviceTokenMintRequest input DTO (platform / appVersion / installId, all validated alphanumeric + length) + DeviceTokenDto output ({token, expiresInSec} matching the native ApiClient contract).
- DeviceTokenMinter generates 64-hex bytes, stores via the existing AccessTokenStore against the configured $deviceMemberId (env DEVICE_MEMBER_ID). Every minted token resolves through ApiAccessTokenHandler → the same Member the Nuxt server proxies through, so downstream authorization is unchanged.
- DeviceTokenProcessor: thin ProcessorInterface implementation, delegates to the minter.
- RateLimitSubscriber wires limiter.device_token_mint (token bucket: burst 6, refill 1/min, per-IP key) on '/api/device-tokens'.
- security.yaml: '^/api/device-tokens' in PUBLIC_ACCESS for prod / dev / test.
- .env: DEVICE_MEMBER_ID= placeholder (per-deployment operator value); set in .env.local (gitignored) to an existing enabled Member.id.
- .env.test.dist: DEVICE_MEMBER_ID='1' for the WebTestCase fixtures.

Tests
- DeviceTokenMinterTest: 64-hex token shape, ttl, store binding, distinctness.
- DeviceTokenResourceTest: 201 happy path, distinct tokens across mints, 422 on missing/garbage installId, 201 without any Authorization header.
