### PR TITLE
chore(containers): cap container memory

### DIFF
--- a/provisioning/containers/docker-compose.yaml
+++ b/provisioning/containers/docker-compose.yaml
@@ -16,6 +16,10 @@ services:
         image: redis:7-bookworm
         command: redis-server --appendonly yes
         restart: always
+        # Cap container memory, so a runaway process cannot exhaust the
+        # host and take the other services down with it. Sized from
+        # observed steady-state usage with generous headroom.
+        mem_limit: 256m
         volumes:
             - '../volumes/cache:/data'
 
@@ -32,6 +36,11 @@ services:
         env_file:
             - '../../.env.local'
         restart: always
+        # Cap container memory, so a runaway process cannot exhaust the
+        # host and take the other services down with it. Sized from
+        # observed steady-state usage with headroom; revisit alongside
+        # the php-fpm pool sizing rather than raising it on its own.
+        mem_limit: 2g
         volumes:
             - './service/templates/extensions.ini.dist:/usr/local/etc/php/conf.d/extensions.ini'
             - './service/templates/docker.conf:/usr/local/etc/php-fpm.d/docker.conf'


### PR DESCRIPTION
Neither the `service` nor the `cache` container declared a memory limit, so a runaway process could consume all available memory on its host and take the other services down with it.

| service | limit |
|---|---|
| `service` (php-fpm) | `2g` |
| `cache` (redis) | `256m` |

### Why `mem_limit` rather than `deploy.resources`

`deploy.*` is swarm-oriented; `mem_limit` is the key Compose v2 honours directly for `compose up`.

### Caveats worth reading

These are **starting points, not tuned values**, sized from observed steady-state usage with headroom.

This pool is configured `pm.max_children = 300` with `pm.start_servers = 300` and `pm.min_spare_servers = 150`. Combined with a 128 MB PHP `memory_limit` per request, a pathological load could in theory exceed the cap and get the container OOM-killed rather than merely slowed.

Worth noting so the sizing isn't misread: summing RSS across php-fpm workers badly overstates real usage, because it counts the shared opcache and libraries once per process. Measured by PSS, each worker's genuine private footprint is only a few MB. So a large pool is not primarily a memory problem — it is a process-count problem. Right-sizing `pm.max_children` is the companion change to this one, and would make the cap comfortable rather than merely adequate.

Swap behaviour is deliberately left at its default; `memswap_limit` is not set.

### Applying

Merging changes nothing by itself. Docker applies memory limits when a container is **created**, not when it is restarted, so this takes effect at the next deployment that recreates the containers.